### PR TITLE
Solving modals issues

### DIFF
--- a/administrator/components/com_localise/tmpl/package/edit.php
+++ b/administrator/components/com_localise/tmpl/package/edit.php
@@ -15,7 +15,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
 HTMLHelper::_('behavior.formvalidator');
-HTMLHelper::_('jquery.framework');
+\Joomla\CMS\HTML\HTMLHelper::_('bootstrap.modal', '.modal', []);
+JHtml::_('jquery.framework');
 
 
 $fieldSets = $this->form->getFieldsets();

--- a/administrator/components/com_localise/tmpl/packages/default.php
+++ b/administrator/components/com_localise/tmpl/packages/default.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
 HTMLHelper::_('stylesheet', 'com_localise/localise.css', ['version' => 'auto', 'relative' => true]);
+\Joomla\CMS\HTML\HTMLHelper::_('bootstrap.modal', '.modal', []);
+JHtml::_('jquery.framework');
 //HTMLHelper::_('formbehavior.chosen', 'select');
 //HTMLHelper::_('jquery.framework');
 //HTMLHelper::_('bootstrap.tooltip');


### PR DESCRIPTION
This one should solve the issues about modal cases that does not work i have founded at buttons "Import XML files" and "Import Special files"

Mainly due was missed to include  "JQuery" call or the new  `\Joomla\CMS\HTML\HTMLHelper::_('bootstrap.modal', '.modal', []);`

Seems than now if we wanna also render, for example, Tooltips we need to also add the:

`\Joomla\CMS\HTML\HTMLHelper::_('bootstrap.tooltip', '.selector', []);`

I have found this useful info about it:

https://docs.joomla.org/J4.x:Using_Bootstrap_in_Joomla_4
