### PR TITLE
Edit package issue

### DIFF
--- a/administrator/components/com_localise/Field/TranslationsField.php
+++ b/administrator/components/com_localise/Field/TranslationsField.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Filesystem\Folder;
-use Joomla\CMS\Form\Field\GroupedListField;
+use Joomla\CMS\Form\Field\GroupedlistField;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\Component\Localise\Administrator\Helper\LocaliseHelper;
@@ -28,7 +28,7 @@ include_once JPATH_ADMINISTRATOR . '/components/com_localise/Helper/defines.php'
  *
  * @since       1.0
  */
-class TranslationsField extends GroupedListField
+class TranslationsField extends GroupedlistField
 {
 	/**
 	 * The field type.

--- a/administrator/components/com_localise/tmpl/packagefile/edit.php
+++ b/administrator/components/com_localise/tmpl/packagefile/edit.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;


### PR DESCRIPTION
This one was happening when i was trying to access at "New" Button to create an "Extension package"

Seems it is only add `use Joomla\CMS\Factory;` to avoid this one:

![missed_factory](https://user-images.githubusercontent.com/417247/130516246-68c17ed9-513b-4e24-ab18-4df701d16c7a.png)

Once this problem is solved and having access, it also does not leave the selected translation files highlighted after saving: as with the core packages.

I have been trying to solve the latter for several days and I will give you a summary at other PR of the progress ... but it is being hard for me to find.