### PR TITLE
Reformat ini files in extension language folder

### DIFF
--- a/administrator/components/com_localise/Model/LanguagesModel.php
+++ b/administrator/components/com_localise/Model/LanguagesModel.php
@@ -288,6 +288,52 @@ class LanguagesModel extends ListModel
 	 */
 	public function reformat()
 	{
+		// Reformat ini files in extensions language folder
+		$scans = LocaliseHelper::getScans();
+
+		foreach ($scans as $scan)
+		{
+			$prefix     = $scan['prefix'];
+			$suffix     = $scan['suffix'];
+			$type       = $scan['type'];
+			$client     = ucfirst($scan['client']);
+			$path       = $scan['path'];
+			$folder     = $scan['folder'];
+			$extensions = Folder::folders($path);
+
+			foreach ($extensions as $extension)
+			{
+				if (Folder::exists("$path$extension/language"))
+				{
+					$tags = Folder::folders("$path$extension/language");
+
+					foreach ($tags as $tag)
+					{
+						$extlangpath = $path . $extension . '/language/' . $tag;
+						$inifiles    = Folder::files($extlangpath, '.ini$');
+
+						foreach ($inifiles as $inifile)
+						{
+							$newinifile = str_replace($tag . '.', '', $inifile);
+							rename( $extlangpath . '/' . $inifile,  $extlangpath . '/' . $newinifile);
+
+							if (strpos($inifile, $tag . '.') !== false)
+							{
+								$shortpath  = str_replace(JPATH_ROOT . '/', '', $path);
+
+								Factory::getApplication()->enqueueMessage(Text::sprintf('COM_LOCALISE_REFORMAT_EXTENSION_SUCCESS', $shortpath . $extension . '/language/' . $tag . '/'), 'message');
+
+								$return = true;
+							}
+						}
+					}
+				}
+			}
+		}
+
+		// End scanning for extensions language folders
+		// Start core language folders
+
 		$clients = array('site', 'administrator');
 
 		if (LocaliseHelper::hasInstallation())

--- a/administrator/components/com_localise/language/en-GB/com_localise.ini
+++ b/administrator/components/com_localise/language/en-GB/com_localise.ini
@@ -158,6 +158,7 @@ COM_LOCALISE_PURGE="Purge Database"
 COM_LOCALISE_PURGE_FAILED="Failed to purge the localise table."
 COM_LOCALISE_PURGE_SUCCESS="The localise table has been emptied successfully."
 COM_LOCALISE_REFORMAT="Reformat j3 languages"
+COM_LOCALISE_REFORMAT_EXTENSION_SUCCESS="The \"%1$s\" ini files have been reformatted." ; The variable is the path to the extension
 COM_LOCALISE_REFORMAT_NONE="No more j3 languages need reformatting."
 COM_LOCALISE_REFORMAT_SUCCESS="The J3 \"%1$s %2$s\" language has been reformatted."
 COM_LOCALISE_SUBMENU_LANGUAGES="Languages"


### PR DESCRIPTION
AS title says.

Make sure to add a language tag to some com_localise strings (as we took them out 2 days ago), for example:
```
language/fr-FR/fr-FR.com_localise.ini
language/fr-FR/fr-FR.com_localise.sys.ini
```
patch and load 5.0.0-dev 
load com_localise languages manager

![Screen Shot 2021-09-07 at 19 38 13](https://user-images.githubusercontent.com/869724/132389234-1182bf39-14ad-4e6e-9b3a-073fd40f812b.png)

Result
![Screen Shot 2021-09-07 at 19 54 53](https://user-images.githubusercontent.com/869724/132389496-2debe0b9-f057-4d95-88f7-0202abf94ede.png)

