### PR TITLE
Correcting parsing error since using : in Key

### DIFF
--- a/administrator/components/com_localise/Model/TranslationModel.php
+++ b/administrator/components/com_localise/Model/TranslationModel.php
@@ -453,7 +453,7 @@ class TranslationModel extends AdminModel
 						$lineNumber++;
 						$line = str_replace('\"', '"_QQ_"', $line);
 
-						if (!preg_match('/^(|(\[[^\]]*\])|([A-Z][A-Z0-9_\*\-\.]*\s*=(\s*(("[^"]*")|(_QQ_)))+))\s*(;.*)?$/', $line))
+						if (!preg_match('/^(|(\[[^\]]*\])|([A-Z][A-Z0-9_:\*\-\.]*\s*=(\s*(("[^"]*")|(_QQ_)))+))\s*(;.*)?$/', $line))
 						{
 							$this->item->error[] = $lineNumber;
 						}
@@ -966,7 +966,7 @@ class TranslationModel extends AdminModel
 						continue;
 					}
 					// Key lines
-					elseif (preg_match('/^([A-Z][A-Z0-9_\*\-\.]*)\s*=/', $line, $matches))
+					elseif (preg_match('/^([A-Z][A-Z0-9_:\*\-\.]*)\s*=/', $line, $matches))
 					{
 						$header     = false;
 						$key        = $matches[1];
@@ -1061,7 +1061,7 @@ class TranslationModel extends AdminModel
 						$field->addAttribute('filter', 'raw');
 						continue;
 					}
-					elseif (!preg_match('/^(|(\[[^\]]*\])|([A-Z][A-Z0-9_\*\-\.]*\s*=(\s*(("[^"]*")|(_QQ_)))+))\s*(;.*)?$/', $line))
+					elseif (!preg_match('/^(|(\[[^\]]*\])|([A-Z][A-Z0-9_:\*\-\.]*\s*=(\s*(("[^"]*")|(_QQ_)))+))\s*(;.*)?$/', $line))
 					{
 						$this->item->error[] = $lineNumber;
 					}
@@ -1378,7 +1378,7 @@ class TranslationModel extends AdminModel
 					$contents[] = "[" . $matches[1] . "]\n";
 				}
 				// Key lines
-				elseif (preg_match('/^([A-Z][A-Z0-9_\*\-\.]*)\s*=/', $line, $matches))
+				elseif (preg_match('/^([A-Z][A-Z0-9_:\*\-\.]*)\s*=/', $line, $matches))
 				{
 					$key = $matches[1];
 					$commented = '';

--- a/media/com_localise/js/parseini.js
+++ b/media/com_localise/js/parseini.js
@@ -40,9 +40,9 @@ CodeMirror.defineMode("parseini", function() {
 				stream.skipTo("]"); stream.eat("]");
 				return "group";
 			}
-			else if (sol && /[A-Z_\.]/.test(ch) && state.position === 'identifier')
+			else if (sol && /[A-Z_:\.]/.test(ch) && state.position === 'identifier')
 			{
-				stream.eatWhile(/[A-Z_\*\.\-0-9]/);
+				stream.eatWhile(/[A-Z_:\*\.\-0-9]/);
 				state.position = "equal";
 				blacklist = ["YES", "NO", "NULL", "FALSE", "ON", "OFF", "NONE", "TRUE"];
 				if(blacklist.indexOf(stream.current()) > -1)


### PR DESCRIPTION
We have new strings in com_admin.ini for 4.0.4 containing `:`
Image after patch
<img width="675" alt="Screen Shot 2021-09-24 at 09 16 35" src="https://user-images.githubusercontent.com/869724/134634028-67f49bf3-ae3b-41d8-bdf3-93d344f3af8b.png">

This works fine as `:` is authorized for parsing inis in general but creates errors in com_localise as `:` is not taken care of when parsing.
This PR adds the `:` in the translation model as well as in parseini.js

Before patch:
<img width="1053" alt="Screen Shot 2021-09-24 at 08 30 39" src="https://user-images.githubusercontent.com/869724/134634168-bb2d9aa0-a494-4cd8-bc1d-d419225099f0.png">

After patch
<img width="796" alt="Screen Shot 2021-09-24 at 09 18 50" src="https://user-images.githubusercontent.com/869724/134634310-d82a19e9-5c38-4889-ae36-4d387a8321ab.png">


@valc
This one is urgent