### PR TITLE
Add spinner for translations view and purge database

### DIFF
--- a/administrator/components/com_localise/tmpl/languages/default.php
+++ b/administrator/components/com_localise/tmpl/languages/default.php
@@ -13,10 +13,27 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Layout\LayoutHelper;
 
-
 HTMLHelper::_('stylesheet', 'com_localise/localise.css', ['version' => 'auto', 'relative' => true]);
 HTMLHelper::_('jquery.framework');
 HTMLHelper::_('behavior.core');
+
+$wa = $this->document->getWebAssetManager();
+$wa->useScript('webcomponent.core-loader');
+$wa->addInlineScript('
+    Joomla.submitbutton = (task) => {
+      "use strict";
+
+      if (task === "languages.purge") {
+        var spinner = document.createElement("joomla-core-loader");
+        document.body.appendChild(spinner);
+        Joomla.submitform(task);
+      }
+      else
+      {
+        Joomla.submitform(task);
+      }
+    }
+');
 
 $listOrder  = $this->escape($this->state->get('list.ordering'));
 $listDirn   = $this->escape($this->state->get('list.direction'));

--- a/administrator/components/com_localise/tmpl/translations/default.php
+++ b/administrator/components/com_localise/tmpl/translations/default.php
@@ -17,6 +17,34 @@ use Joomla\CMS\Router\Route;
 HTMLHelper::_('stylesheet', 'com_localise/localise.css', ['version' => 'auto', 'relative' => true]);
 
 HTMLHelper::_('behavior.core');
+HTMLHelper::_('jquery.framework');
+
+$wa = $this->document->getWebAssetManager();
+$wa->useScript('webcomponent.core-loader');
+$wa->addInlineScript("
+	// Page is loading
+	window.onload = function() {
+		initSpinner();
+	};
+
+	function initSpinner() {
+		spinner = document.createElement('joomla-core-loader');
+		document.body.appendChild(spinner);
+	}
+
+	// Page is loaded
+	jQuery(document).ready(function() {
+		// Close the spinner when page is loaded
+		var spinner = document.querySelector('joomla-core-loader');
+		spinner.parentNode.removeChild(spinner);
+
+		// Any field from the Select fieldset triggers the spinner
+		jQuery('select').change(function(){
+			spinner = document.createElement('joomla-core-loader');
+			document.body.appendChild(spinner);
+		})
+	});
+");
 
 $listOrder  = $this->escape($this->state->get('list.ordering'));
 $listDirn   = $this->escape($this->state->get('list.direction'));


### PR DESCRIPTION
Issue https://github.com/infograf768/j4localise/issues/36
As title says.

Display the languages view and Click on the Purge Database toolbar.

Display the translations view and modify any filter.
Edit a translation file and save and close